### PR TITLE
添加创建指定unique数据的transaction function

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject earthworm "0.2.3"
+(defproject earthworm "0.2.4-SNAPSHOT"
   :description "Common components and utils for server side development"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -7,6 +7,6 @@
                  [org.clojure/core.match "0.2.2"]
                  [com.stuartsierra/component "0.2.2"]
                  [com.taoensso/timbre "3.3.1"]
-                 [com.datomic/datomic-pro "0.9.5067" :exclusions [joda-time]]
+                 [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]
                  [http-kit "2.1.18"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"])

--- a/src/earthworm/util/datomic.clj
+++ b/src/earthworm/util/datomic.clj
@@ -116,6 +116,18 @@
                  (concat (map (fn [v] [:db/retract eid attr v]) to-be-retract)
                          (when (seq to-be-add) [{:db/id eid attr (vec to-be-add)}])))})
 
+(def create-unique-data
+  "根据指定的unique键, 创建唯一一条数据, 若unique指定数据已经被创建, 则本条数据不会写入数据库;
+  本函数旨满足要指定组合型唯一约束的场景, datomic数据库定义时不能指定组合唯一约束.
+  lookup-define 使用 lookup-eid 中的定义."
+  #db/fn
+      {:lang :clojure
+       :params [db lookup-define new-data]
+       :code (let [fn-lookup-eid (-> (d/entity db :db.fn/lookup-eid) :db/fn)
+                   eid (fn-lookup-eid db lookup-define)]
+               (when-not eid
+                 new-data))})
+
 ;;============================
 
 (defn mk-db-schema
@@ -152,7 +164,7 @@
   "内嵌在每个数据库的函数"
   (entities
     :db.part/user
-    (mapv db-fn [#'seq-id #'atom-plus #'lookup-eid #'smart-atom-plus #'create-or-update #'update-set])))
+    (mapv db-fn [#'seq-id #'atom-plus #'lookup-eid #'smart-atom-plus #'create-or-update #'update-set #'create-unique-data])))
 
 (defn init-conn
   "用数据库定义来新生成数据库, 返回到它的连接. 如果不指定 uri, 将随机生成一个内存数据库. 用于测试."

--- a/src/earthworm/util/datomic.clj
+++ b/src/earthworm/util/datomic.clj
@@ -66,14 +66,17 @@
        :params [db lookup-define]
        :code (let [id (first lookup-define)
                    [component-key kvs] (second lookup-define)]
-               (if component-key
-                 (let [where-cluase (mapv #(apply vector '?l %) kvs)]
-                   (ffirst (d/q {:find  ['?l]
-                                 :in    ['$ '?id]
-                                 :where (concat [['?id component-key '?l]]
-                                                where-cluase)}
-                                db id)))
-                 (-> (d/entity db id) :db/id)))})
+               (try
+                 (if component-key
+                   (let [where-cluase (mapv #(apply vector '?l %) kvs)]
+                     (ffirst (d/q {:find  ['?l]
+                                   :in    ['$ '?id]
+                                   :where (concat [['?id component-key '?l]]
+                                                  where-cluase)}
+                                  db id)))
+                   (-> (d/entity db id) :db/id))
+                 (catch Exception e
+                   nil)))})
 
 (def smart-atom-plus
   "在数据库中对指定属性 attr 上增加 amount (先取再加) 的高级版本,


### PR DESCRIPTION
- 根据指定的unique键, 创建唯一一条数据, 若unique指定数据已经被创建, 则本条数据不会写入数据库;
- 本函数旨满足要指定组合型唯一约束的场景, datomic数据库定义时不能指定组合唯一约束.
- 在仓库中找不到到 com.datomic/datomic-pro "0.9.5067"包？暂时改为了free版本。
